### PR TITLE
add variables

### DIFF
--- a/samples/test.sol
+++ b/samples/test.sol
@@ -1,0 +1,33 @@
+pragma solidity ^0.4.22;
+pragma solidity 0.4.22;
+pragma experimental something;
+
+
+contract Parent {
+
+    // Declaring internal
+    // state variable
+    uint internal parent_sum;
+
+    // Defining external function
+    // to set value of internal
+    // state variable sum
+    function setValue() external {
+        uint a = 10;
+        uint b = 20;
+        parent_sum = a + b;
+    }
+}
+
+contract Child is Parent {
+
+    uint public own_value;
+
+    // Defining external function
+    // to return value of
+    // internal state variable parent_sum
+    function getValue(
+    ) external view returns(uint) {
+        return parent_sum;
+    }
+}


### PR DESCRIPTION
# Update `outline` to included inherited contract values
The following changes update the `outline` option to include inherited attributes for contracts.

## Example:
In this section an example is provided showing what the new code does.


### Example .sol file:
The .sol file used for the example:
```solidity
pragma solidity ^0.4.22;
pragma solidity 0.4.22;
pragma experimental something;


contract Parent {

    // Declaring internal
    // state variable
    uint internal parent_sum;

    // Defining external function
    // to set value of internal
    // state variable sum
    function setValue() external {
        uint a = 10;
        uint b = 20;
        parent_sum = a + b;
    }
}

contract Child is Parent {

    uint public own_value;

    // Defining external function
    // to return value of
    // internal state variable parent_sum
    function getValue(
    ) external view returns(uint) {
        return parent_sum;
    }
}
```

### Previous output of `outline`
```shell
=== pragmas ===
	* {'type': 'PragmaDirective', 'name': 'solidity', 'value': '^0.4.22'}
	* {'type': 'PragmaDirective', 'name': 'solidity', 'value': '0.4.22'}
	* {'type': 'PragmaDirective', 'name': 'experimental', 'value': 'something'}
=== imports ===
=== contract: Parent
	=== Inherited Contracts: 
	=== Enums
	=== Structs
	=== statevars
			* parent_sum
	=== modifiers
	=== functions
			* setValue (external)
=== contract: Child
		=== Inherited Contracts: Parent
		=== Enums
		=== Structs
		=== statevars
				* own_value
		=== modifiers
		=== functions
				* getValue (external,view)
```

### New output of `outline`
The statevar `own_value` and the function `setValue` are now included in the contract `Child`.
```shell
=== pragmas ===
	* {'type': 'PragmaDirective', 'name': 'solidity', 'value': '^0.4.22'}
	* {'type': 'PragmaDirective', 'name': 'solidity', 'value': '0.4.22'}
	* {'type': 'PragmaDirective', 'name': 'experimental', 'value': 'something'}
=== imports ===
=== contract: Parent
	=== Inherited Contracts: 
	=== Enums
	=== Structs
	=== statevars
			* parent_sum
	=== modifiers
	=== functions
			* setValue (external)
=== contract: Child
		=== Inherited Contracts: Parent
		=== Enums
		=== Structs
		=== statevars
				* parent_sum
				* own_value
		=== modifiers
		=== functions
				* setValue (external)
				* getValue (external,view)
```

## Code changes
The only file that is changed is the `parser.py`. Two sections are updated:
 * `ObjectifyContractVisitor` in `Objectify` has a new method called **inheritFromParents**
 * For each contract all attributes of its base/parent contracts are copied over. 
   This happens in the method `visitContractDefinition`.

### Changes in ObjectifyContractVisitor
These are new lines from line 1206-1216.
```python
...
        def inheritFromParents(self, parent) -> None:
            """This method inherits values from the parents such that they are added to this object.

            TODO:
                Remove private statevars.
            """
            self.enums = dict(list(parent.enums.items()) + list(self.enums.items()))
            self.structs = dict(list(parent.structs.items()) + list(self.structs.items()))
            self.stateVars = dict(list(parent.stateVars.items()) + list(self.stateVars.items()))
            self.modifiers = dict(list(parent.modifiers.items()) + list(self.modifiers.items()))
            self.functions = dict(list(parent.functions.items()) + list(self.functions.items()))
...
```

### Changes in ObjectifyContractVisitor
The new lines from line 1358-1359.
The for loop over the base contracts is new.
```diff
...
        def visitContractDefinition(self, node):
+            self.contracts[node.name] = ObjectifyContractVisitor(node)
+            for bc in node.baseContracts:
                self.contracts[node.name].inheritFromParents(self.contracts[bc.baseName.namePath])

            # subparse the contracts //slightly inefficient but more readable :)
            visit(node, self.contracts[node.name])
...
```

